### PR TITLE
Cleanup JSB Lowercase Name

### DIFF
--- a/CefSharp.Core/ManagedCefBrowserAdapter.h
+++ b/CefSharp.Core/ManagedCefBrowserAdapter.h
@@ -661,9 +661,9 @@ namespace CefSharp
             }
         }
 
-		void RegisterJsObject(String^ name, Object^ object, bool lowerCaseJavascriptNames)
+        void RegisterJsObject(String^ name, Object^ object, bool lowerCaseJavascriptNames)
         {
-			_javaScriptObjectRepository->Register(name, object, lowerCaseJavascriptNames);
+            _javaScriptObjectRepository->Register(name, object, lowerCaseJavascriptNames);
         }
 
         void ReplaceMisspelling(String^ word)

--- a/CefSharp.OffScreen/ChromiumWebBrowser.cs
+++ b/CefSharp.OffScreen/ChromiumWebBrowser.cs
@@ -304,11 +304,7 @@ namespace CefSharp.OffScreen
             Load(url);
         }
 
-        public void RegisterJsObject(string name, object objectToBind)
-        {
-            RegisterJsObject(name, objectToBind, true);
-        }
-        public void RegisterJsObject(string name, object objectToBind, bool lowerCaseJavascriptNames)
+        public void RegisterJsObject(string name, object objectToBind, bool lowerCaseJavascriptNames = true)
         {
             managedCefBrowserAdapter.RegisterJsObject(name, objectToBind, lowerCaseJavascriptNames);
         }

--- a/CefSharp.WinForms/ChromiumWebBrowser.cs
+++ b/CefSharp.WinForms/ChromiumWebBrowser.cs
@@ -198,11 +198,7 @@ namespace CefSharp.WinForms
             Load(url);
         }
 
-        public void RegisterJsObject(string name, object objectToBind) 
-        {
-            RegisterJsObject(name, objectToBind, true);
-        }
-        public void RegisterJsObject(string name, object objectToBind, bool lowerCaseJavascriptNames)
+        public void RegisterJsObject(string name, object objectToBind, bool lowerCaseJavascriptNames = true)
         {
             managedCefBrowserAdapter.RegisterJsObject(name, objectToBind, lowerCaseJavascriptNames);
         }

--- a/CefSharp.Wpf/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf/ChromiumWebBrowser.cs
@@ -1390,12 +1390,7 @@ namespace CefSharp.Wpf
             managedCefBrowserAdapter.CloseDevTools();
         }
 
-        public void RegisterJsObject(string name, object objectToBind)
-        {
-            RegisterJsObject( name, objectToBind, true);
-        }
-
-        public void RegisterJsObject(string name, object objectToBind, bool lowerCaseJavascriptNames)
+        public void RegisterJsObject(string name, object objectToBind, bool lowerCaseJavascriptNames = true)
         {
             managedCefBrowserAdapter.RegisterJsObject(name, objectToBind, lowerCaseJavascriptNames);
         }

--- a/CefSharp/IWebBrowser.cs
+++ b/CefSharp/IWebBrowser.cs
@@ -86,7 +86,8 @@ namespace CefSharp
         /// </summary>
         /// <param name="name">The name of the object. (e.g. "foo", if you want the object to be accessible as window.foo).</param>
         /// <param name="objectToBind">The object to be made accessible to Javascript.</param>
-        void RegisterJsObject(string name, object objectToBind);
+        /// <param name="lowerCaseJavascriptNames">lower-case the names of properties/methods, defaults to true</param>
+        void RegisterJsObject(string name, object objectToBind, bool lowerCaseJavascriptNames = true);
 
         /// <summary>
         /// Execute some Javascript code in the context of this WebBrowser. As the method name implies, the script will be

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -210,14 +210,7 @@ namespace CefSharp.Internals
                 {
                     var jsObject = CreateJavascriptObject();
                     jsObject.Name = propertyInfo.Name;
-
-                    // depending on lowerCaseJavascriptNames JS Properties will be lowercase or unaltered 
-                    // defaults to LowercaseFirst, in order to not change existing behaviour
-                    if (lowerCaseJavascriptNames)
-                        jsObject.JavascriptName = LowercaseFirst(propertyInfo.Name);
-                    else
-                        jsObject.JavascriptName = propertyInfo.Name;
-
+                    jsObject.JavascriptName = LowercaseFirst(propertyInfo.Name, lowerCaseJavascriptNames);
                     jsObject.Value = jsProperty.GetValue(obj.Value);
                     jsProperty.JsObject = jsObject;
 
@@ -236,12 +229,7 @@ namespace CefSharp.Internals
             var jsMethod = new JavascriptMethod();
 
             jsMethod.ManagedName = methodInfo.Name;
-
-            if (lowerCaseJavascriptNames)
-                jsMethod.JavascriptName = LowercaseFirst(methodInfo.Name);
-            else
-                jsMethod.JavascriptName = methodInfo.Name;
-
+            jsMethod.JavascriptName = LowercaseFirst(methodInfo.Name, lowerCaseJavascriptNames);
             jsMethod.Function = methodInfo.Invoke;
             jsMethod.ParameterCount = methodInfo.GetParameters().Length;
 
@@ -253,12 +241,7 @@ namespace CefSharp.Internals
             var jsProperty = new JavascriptProperty();
 
             jsProperty.ManagedName = propertyInfo.Name;
-
-            if (lowerCaseJavascriptNames)
-                jsProperty.JavascriptName = LowercaseFirst(propertyInfo.Name);
-            else
-                jsProperty.JavascriptName = propertyInfo.Name;
-
+            jsProperty.JavascriptName = LowercaseFirst(propertyInfo.Name, lowerCaseJavascriptNames);
             jsProperty.SetValue = (o, v) => propertyInfo.SetValue(o, v, null);
             jsProperty.GetValue = (o) => propertyInfo.GetValue(o, null);
 
@@ -292,8 +275,13 @@ namespace CefSharp.Internals
             return !baseType.IsPrimitive && baseType != typeof(string);
         }
 
-        private static string LowercaseFirst(string str)
+        private static string LowercaseFirst(string str, bool lowerCaseJavascriptNames)
         {
+            if (!lowerCaseJavascriptNames)
+            {
+                return str;
+            }
+
             if (string.IsNullOrEmpty(str))
             {
                 return string.Empty;

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -35,7 +35,6 @@ namespace CefSharp.Internals
             return result;
         }
 
-        public void Register(string name, object value) {  Register(name, value, true); }
         public void Register(string name, object value, bool lowerCaseJavascriptNames)
         {
             var jsObject = CreateJavascriptObject();
@@ -89,7 +88,7 @@ namespace CefSharp.Internals
                     jsObject.Name = "FunctionResult(" + name + ")";
                     jsObject.JavascriptName = jsObject.Name;
 
-                    AnalyseObjectForBinding(jsObject, analyseMethods: false, readPropertyValue: true);
+                    AnalyseObjectForBinding(jsObject, analyseMethods: false, readPropertyValue: true, lowerCaseJavascriptNames:true);
 
                     result = jsObject;
                 }
@@ -171,10 +170,6 @@ namespace CefSharp.Internals
         /// <param name="analyseMethods">Analyse methods for inclusion in metadata model</param>
         /// <param name="readPropertyValue">When analysis is done on a property, if true then get it's value for transmission over WCF</param>
         /// <param name="lowerCaseJavascriptNames">decide wether your JS mathods and properties are automatically lowercased or not</param>
-        private void AnalyseObjectForBinding(JavascriptObject obj, bool analyseMethods, bool readPropertyValue) 
-        {
-            AnalyseObjectForBinding(obj, analyseMethods, readPropertyValue, true);
-        }
         private void AnalyseObjectForBinding(JavascriptObject obj, bool analyseMethods, bool readPropertyValue, bool lowerCaseJavascriptNames)
         {
             if (obj.Value == null)
@@ -226,7 +221,7 @@ namespace CefSharp.Internals
                     jsObject.Value = jsProperty.GetValue(obj.Value);
                     jsProperty.JsObject = jsObject;
 
-                    AnalyseObjectForBinding(jsProperty.JsObject, analyseMethods, readPropertyValue);
+                    AnalyseObjectForBinding(jsProperty.JsObject, analyseMethods, readPropertyValue, lowerCaseJavascriptNames);
                 }
                 else if (readPropertyValue)
                 {
@@ -236,10 +231,6 @@ namespace CefSharp.Internals
             }
         }
 
-        private static JavascriptMethod CreateJavaScriptMethod(MethodInfo methodInfo) 
-        {
-            return CreateJavaScriptMethod(methodInfo, true); 
-        }
         private static JavascriptMethod CreateJavaScriptMethod(MethodInfo methodInfo, bool lowerCaseJavascriptNames)
         {
             var jsMethod = new JavascriptMethod();
@@ -257,10 +248,6 @@ namespace CefSharp.Internals
             return jsMethod;
         }
 
-        private static JavascriptProperty CreateJavaScriptProperty(PropertyInfo propertyInfo)
-        {
-            return CreateJavaScriptProperty(propertyInfo, true);
-        }
         private static JavascriptProperty CreateJavaScriptProperty(PropertyInfo propertyInfo, bool lowerCaseJavascriptNames)
         {
             var jsProperty = new JavascriptProperty();

--- a/CefSharp/Internals/JavascriptObjectRepository.cs
+++ b/CefSharp/Internals/JavascriptObjectRepository.cs
@@ -210,7 +210,7 @@ namespace CefSharp.Internals
                 {
                     var jsObject = CreateJavascriptObject();
                     jsObject.Name = propertyInfo.Name;
-                    jsObject.JavascriptName = LowercaseFirst(propertyInfo.Name, lowerCaseJavascriptNames);
+                    jsObject.JavascriptName = GetJavascriptName(propertyInfo.Name, lowerCaseJavascriptNames);
                     jsObject.Value = jsProperty.GetValue(obj.Value);
                     jsProperty.JsObject = jsObject;
 
@@ -229,7 +229,7 @@ namespace CefSharp.Internals
             var jsMethod = new JavascriptMethod();
 
             jsMethod.ManagedName = methodInfo.Name;
-            jsMethod.JavascriptName = LowercaseFirst(methodInfo.Name, lowerCaseJavascriptNames);
+            jsMethod.JavascriptName = GetJavascriptName(methodInfo.Name, lowerCaseJavascriptNames);
             jsMethod.Function = methodInfo.Invoke;
             jsMethod.ParameterCount = methodInfo.GetParameters().Length;
 
@@ -241,7 +241,7 @@ namespace CefSharp.Internals
             var jsProperty = new JavascriptProperty();
 
             jsProperty.ManagedName = propertyInfo.Name;
-            jsProperty.JavascriptName = LowercaseFirst(propertyInfo.Name, lowerCaseJavascriptNames);
+            jsProperty.JavascriptName = GetJavascriptName(propertyInfo.Name, lowerCaseJavascriptNames);
             jsProperty.SetValue = (o, v) => propertyInfo.SetValue(o, v, null);
             jsProperty.GetValue = (o) => propertyInfo.GetValue(o, null);
 
@@ -275,7 +275,7 @@ namespace CefSharp.Internals
             return !baseType.IsPrimitive && baseType != typeof(string);
         }
 
-        private static string LowercaseFirst(string str, bool lowerCaseJavascriptNames)
+        private static string GetJavascriptName(string str, bool lowerCaseJavascriptNames)
         {
             if (!lowerCaseJavascriptNames)
             {


### PR DESCRIPTION
Simplified your changes based on the feedback given. `lowerCaseJavascriptNames` should now be passed recursively.
